### PR TITLE
Standardize method description fields

### DIFF
--- a/source/helpers/typography_helper.rst
+++ b/source/helpers/typography_helper.rst
@@ -27,10 +27,10 @@
 
 .. php:function:: auto_typography($str[, $reduce_linebreaks = FALSE])
 
-	:パラメータ	string	$str: 入力文字
-	:パラメータ	bool	$reduce_linebreaks: 複数の重複した改行を2つにするかどうか
-	:返り値:	HTML フォーマットされた体裁が整った文字列
-	:返り値型: string
+	:param	string	$str: 入力文字
+	:param	bool	$reduce_linebreaks: 複数の重複した改行を2つにするかどうか
+	:returns:	HTML フォーマットされた体裁が整った文字列
+	:rtype: string
 
 	意味論的にも文の体裁を整える面でも正しい HTML
 	にテキストをフォーマットします。
@@ -51,9 +51,9 @@
 
 .. php:function:: nl2br_except_pre($str)
 
-	:パラメータ	string	$str: 入力文字列
-	:返り値:	HTML フォーマットされた改行を含む文字列
-	:返り値型:	string
+	:param	string	$str: 入力文字列
+	:returns:	HTML フォーマットされた改行を含む文字列
+	:rtype:	string
 
 	<pre>タグの中でない改行を<br />タグに変換します。
 	この関数は<pre>タグを無視しないという点を除いて、
@@ -65,10 +65,10 @@
 
 .. php:function:: entity_decode($str, $charset = NULL)
 
-	:パラメータ	string	$str: 入力文字列
-	:パラメータ	string	$charset: 入力文字列の文字セット
-	:返り値:	エンティティデコードされた文字列
-	:返り値型:	string
+	:param	string	$str: 入力文字列
+	:param	string	$charset: 入力文字列の文字セット
+	:returns:	エンティティデコードされた文字列
+	:rtype:	string
 
 	この関数は ``CI_Security::entity_decode()`` のエイリアスです。
 	より多くの情報を得るには、:doc:`セキュリティクラス<../libraries/security>`

--- a/source/helpers/url_helper.rst
+++ b/source/helpers/url_helper.rst
@@ -26,10 +26,10 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: site_url([$uri = ''[, $protocol = NULL]])
 
-	:パラメータ	string $uri: URI 文字列
-	:パラメータ	string	$protocol: プロトロコル, 例: 'http' or 'https'
-	:返り値:	サイトの URL
-	:返り値型:	string
+	:param	string $uri: URI 文字列
+	:param	string	$protocol: プロトロコル, 例: 'http' or 'https'
+	:returns:	サイトの URL
+	:rtype:	string
 
 	設定ファイルで指定されているサイトの URL を返します。 index.php
 	ファイル (または、設定ファイルで設定しているユーザサイトの **index_page**
@@ -58,10 +58,10 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: base_url($uri = '', $protocol = NULL)
 
-	:パラメータ	string	$uri: URI 文字列
-	:パラメータ	string	$protocol: プロトロコル, 例: 'http' or 'https'
-	:返り値:	ベース URL
-	:返り値型:	string
+	:param	string	$uri: URI 文字列
+	:param	string	$protocol: プロトロコル, 例: 'http' or 'https'
+	:returns:	ベース URL
+	:rtype:	string
 
 	設定ファイルで指定されているサイトのベース URL を返します。例::
 
@@ -91,8 +91,8 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: current_url()
 
-	:返り値:	現在の URL
-	:返り値型:	string
+	:returns:	現在の URL
+	:rtype:	string
 
 	現在表示されているページの完全な URL (セグメントを含む) を
 	返します。
@@ -104,8 +104,8 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: uri_string()
 
-	:返り値:	An URI string
-	:返り値型:	string
+	:returns:	An URI string
+	:rtype:	string
 
 	この関数が呼び出されたページの URI セグメントを返します。たとえば、URL
 	が以下のようなものであれば::
@@ -122,8 +122,8 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: index_page()
 
-	:返り値:	'index_page' value
-	:返り値型:	mixed
+	:returns:	'index_page' value
+	:rtype:	mixed
 
 	設定ファイルで指定されているサイトの **index_page** ページを返します。
 	例::
@@ -132,11 +132,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: anchor($uri = '', $title = '', $attributes = '')
 
-	:パラメータ	string	$uri: URI 文字列
-	:パラメータ	string	$title: アンカータイトル
-	:パラメータ	mixed	$attributes: HTML 属性
-	:返り値:	HTML ハイパーリンク (アンカータグ)
-	:返り値型:	string
+	:param	string	$uri: URI 文字列
+	:param	string	$title: アンカータイトル
+	:param	mixed	$attributes: HTML 属性
+	:returns:	HTML ハイパーリンク (アンカータグ)
+	:rtype:	string
 
 	サイトの URL にもとづいて、標準の HTML アンカーリンクを生成します。
 
@@ -170,11 +170,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: anchor_popup($uri = '', $title = '', $attributes = FALSE)
 
-	:パラメータ	string	$uri: URI 文字列
-	:パラメータ	string	$title: アンカータイトル
-	:パラメータ	mixed	$attributes: HTML 属性
-	:返り値:	ポップアップ ハイパーリンク
-	:返り値型:	string
+	:param	string	$uri: URI 文字列
+	:param	string	$title: アンカータイトル
+	:param	mixed	$attributes: HTML 属性
+	:returns:	ポップアップ ハイパーリンク
+	:rtype:	string
 
 	新しいウィンドで URL を開くこと以外は、 :php:func:`anchor()` 関数とほとんど同じです。
 	ウィンドウの開き方をコントロールするために、JavaScript の window
@@ -214,11 +214,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: mailto($email, $title = '', $attributes = '')
 
-	:パラメータ	string	$email: メールアドレス
-	:パラメータ	string	$title: アンカータイトル
-	:パラメータ	mixed	$attributes: HTML 属性
-	:返り値:	"mail to" ハイパーリンク
-	:返り値型:	string
+	:param	string	$email: メールアドレス
+	:param	string	$title: アンカータイトル
+	:param	mixed	$attributes: HTML 属性
+	:returns:	"mail to" ハイパーリンク
+	:rtype:	string
 
 	標準の HTML メールリンクを作成します。使用例::
 
@@ -232,11 +232,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: safe_mailto($email, $title = '', $attributes = '')
 
-	:パラメータ	string	$email: メールアドレス
-	:パラメータ	string	$title: アンカータイトル
-	:パラメータ	mixed	$attributes: HTML 属性
-	:返り値:	スパムセーフな "mail to" ハイパーリンク
-	:返り値型:	string
+	:param	string	$email: メールアドレス
+	:param	string	$title: アンカータイトル
+	:param	mixed	$attributes: HTML 属性
+	:returns:	スパムセーフな "mail to" ハイパーリンク
+	:rtype:	string
 
 	この関数は、スパムロボットにメールアドレスが収集されてしまうのを防ぐため、
 	メールアドレスのリンクを JavaScript で書き出すために、
@@ -244,11 +244,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: auto_link($str, $type = 'both', $popup = FALSE)
 
-	:パラメータ	string	$str: 入力文字列
-	:パラメータ	string	$type: リンクタイプ ('email', 'url' or 'both')
-	:パラメータ	bool	$popup: ポップアップリンクを生成するかどうか
-	:返り値:	リンク可能な文字列
-	:返り値型:	string
+	:param	string	$str: 入力文字列
+	:param	string	$type: リンクタイプ ('email', 'url' or 'both')
+	:param	bool	$popup: ポップアップリンクを生成するかどうか
+	:returns:	リンク可能な文字列
+	:rtype:	string
 
 	自動で、文字列に含まれる URL とメールアドレスをリンクに変換します。
 	例::
@@ -276,11 +276,11 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: url_title($str, $separator = '-', $lowercase = FALSE)
 
-	:パラメータ	string	$str: 入力文字列
-	:パラメータ	string	$separator: 単語区切り
-	:パラメータ	bool	$lowercase: 小文字に変換して出力するかどうか
-	:返り値:	URL フォーマットの文字列
-	:返り値型:	string
+	:param	string	$str: 入力文字列
+	:param	string	$separator: 単語区切り
+	:param	bool	$lowercase: 小文字に変換して出力するかどうか
+	:returns:	URL フォーマットの文字列
+	:rtype:	string
 
 	入力として文字列をとり、人間にわかりやすい URL 文字列を生成します。
 	これはたとえば、ブログを作成していたとして、その中で記事のタイトルを
@@ -314,9 +314,9 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: prep_url($str = '')
 
-	:パラメータ	string	$str: URL 文字列
-	:返り値:	プロトコル接頭辞を付与した URL 文字列
-	:返り値型:	string
+	:param	string	$str: URL 文字列
+	:returns:	プロトコル接頭辞を付与した URL 文字列
+	:rtype:	string
 
 	この関数は、与えられた URL の文字列にプロトロルがない場合に http&#58;//
 	を追加します。
@@ -328,10 +328,10 @@ URL ヘルパーファイルは、URL を処理するのに役立つ関数で構
 
 .. php:function:: redirect($uri = '', $method = 'auto', $code = NULL)
 
-	:パラメータ	string	$uri: URI 文字列
-	:パラメータ	string	$method: リダイレクトメソッド ('auto', 'location' or 'refresh')
-	:パラメータ	string	$code: HTTP Response Code (通常 302 or 303)
-	:返り値:	void
+	:param	string	$uri: URI 文字列
+	:param	string	$method: リダイレクトメソッド ('auto', 'location' or 'refresh')
+	:param	string	$code: HTTP Response Code (通常 302 or 303)
+	:returns:	void
 
 	指定した URI に対して "ヘッダ リダイレクト" します。完全な URL
 	(http://...) を指定しても生成されますが、

--- a/source/helpers/xml_helper.rst
+++ b/source/helpers/xml_helper.rst
@@ -28,10 +28,10 @@ XML ヘルパーファイルは、 XML データを処理するのに役立つ�
 
 .. php:function:: xml_convert($str[, $protect_all = FALSE])
 
-	:パラメータ string $str: 変換する文字列
-	:パラメータ bool $protect_all: 数値文字エンティティ(例: &foo;)のようなエンティティのように見える可能性のあるコンテンツを全てそのまま出力するかどうか
-	:返り値: XML 変換文字列
-	:返り値型:	string
+	:param string $str: 変換する文字列
+	:param bool $protect_all: 数値文字エンティティ(例: &foo;)のようなエンティティのように見える可能性のあるコンテンツを全てそのまま出力するかどうか
+	:returns: XML 変換文字列
+	:rtype:	string
 
 	文字列を入力とし、次の XML の予約文字を XML
 	エンティティに変換します:

--- a/source/libraries/benchmark.rst
+++ b/source/libraries/benchmark.rst
@@ -135,18 +135,18 @@ PHP をそのまま使用したくないときは、ビューのファイル内�
 
 	.. php:method:: mark($name)
 
-		:パラメータ	string	$name: マーカーにつけたい名前
-		:返り値型:	void
+		:param	string	$name: マーカーにつけたい名前
+		:rtype:	void
 
 		ベンチマークマーカーをセットします。
 
 	.. php:method:: elapsed_time([$point1 = ''[, $point2 = ''[, $decimals = 4]]])
 
-		:パラメータ	string	$point1: 特定のマークされた点
-		:パラメータ	string	$point2: a particular marked point
-		:パラメータ	int	$decimals: 小数点以下の桁数
-		:返り値:	経過時間
-		:返り値型:	string
+		:param	string	$point1: 特定のマークされた点
+		:param	string	$point2: a particular marked point
+		:param	int	$decimals: 小数点以下の桁数
+		:returns:	経過時間
+		:rtype:	string
 
 		2つのマークされた点の時差を計算して、返します。
 
@@ -158,8 +158,8 @@ PHP をそのまま使用したくないときは、ビューのファイル内�
 
 	.. php:method:: memory_usage()
 
-		:返り値:	Memory usage info
-		:返り値型:	string
+		:returns:	Memory usage info
+		:rtype:	string
 
 		単に``{memory_usage}``マーカーを返します。
 

--- a/source/libraries/caching.rst
+++ b/source/libraries/caching.rst
@@ -56,9 +56,9 @@ available in the hosting environment.
 
 	.. php:method:: is_supported($driver)
 
-		:パラメータ	string	$driver: キャッシング・ドライバの名前
-		:返り値:	対応できればTRUE、そうでなければFALSEを返します。
-		:返り値型:	bool
+		:param	string	$driver: キャッシング・ドライバの名前
+		:returns:	対応できればTRUE、そうでなければFALSEを返します。
+		:rtype:	bool
 
 		このメソッドは、``$this->cache->get()`` 経由でドライバにアクセスする際に、
 		自動的に呼び出されます。しかしながら、もし、個別のドライバを使用する
@@ -76,9 +76,9 @@ available in the hosting environment.
 
 	.. php:method:: get($id)
 
-		:パラメータ	string	$id: キャッシュ・アイテム名
-		:返り値:	アイテムが存在しない場合、FALSE を返します。
-		:返り値型:	mixed
+		:param	string	$id: キャッシュ・アイテム名
+		:returns:	アイテムが存在しない場合、FALSE を返します。
+		:rtype:	mixed
 
 		このメソッドはキャッシュから1つのアイテムを取得することを試みます。
 		もしそのアイテムが存在しない場合、このメソッドは FALSE を返します。
@@ -88,12 +88,12 @@ available in the hosting environment.
 
 	.. php:method:: save($id, $data[, $ttl = 60[, $raw = FALSE]])
 
-		:パラメータ	string	$id: キャッシュ・アイテム名
-		:パラメータ	mixed	$data: 保存するデータ
-		:パラメータ	int	$ttl: Time To Live のデフォルトは 60 秒です。
-		:パラメータ	bool	$raw: 元の値を保存するべきかどうか
-		:返り値:	成功時　TRUE、 失敗時　FALSE
-		:返り値型:	string
+		:param	string	$id: キャッシュ・アイテム名
+		:param	mixed	$data: 保存するデータ
+		:param	int	$ttl: Time To Live のデフォルトは 60 秒です。
+		:param	bool	$raw: 元の値を保存するべきかどうか
+		:returns:	成功時　TRUE、 失敗時　FALSE
+		:rtype:	string
 
 		このメソッドはキャッシュに1つのアイテムを保存します。
 		もし、保存に失敗した場合、このメソッドは FALSE を返します。
@@ -106,9 +106,9 @@ available in the hosting environment.
 
 	.. php:method:: delete($id)
 
-		:パラメータ	string	$id: キャッシュされたアイテムの名前
-		:返り値:	成功時 TRUE、失敗時 FALSE
-		:返り値型:	bool
+		:param	string	$id: キャッシュされたアイテムの名前
+		:returns:	成功時 TRUE、失敗時 FALSE
+		:rtype:	bool
 
 		このメソッドは特定の1つのアイテムをキャッシュから削除します。
 		もし、削除に失敗した場合、このメソッドは FALSE を返します。
@@ -118,10 +118,10 @@ available in the hosting environment.
 
 	.. php:method:: increment($id[, $offset = 1])
 
-		:パラメータ	string	$id: キャッシュID
-		:パラメータ	int	$offset: 値に進行上の数値を追加する
-		:返り値:	新しい値が保存されたら成功、失敗時　FALSE 
-		:返り値型:	mixed
+		:param	string	$id: キャッシュID
+		:param	int	$offset: 値に進行上の数値を追加する
+		:returns:	新しい値が保存されたら成功、失敗時　FALSE 
+		:rtype:	mixed
 
 		元の保存された値に極小の増加を実行します。
 		::
@@ -134,10 +134,10 @@ available in the hosting environment.
 
 	.. php:method:: decrement($id[, $offset = 1])
 
-		:パラメータ	string	$id: キャッシュID
-		:パラメータ	int	$offset: S値に進行上の数値を減算する
-		:返り値:	新しい値が保存されたら成功、失敗時　FALSE
-		:返り値型:	mixed
+		:param	string	$id: キャッシュID
+		:param	int	$offset: S値に進行上の数値を減算する
+		:returns:	新しい値が保存されたら成功、失敗時　FALSE
+		:rtype:	mixed
 
 		元の保存された値に極小の減算を実行します。
 		::
@@ -150,8 +150,8 @@ available in the hosting environment.
 
 	.. php:method:: clean()
 
-		:返り値:	成功時　TRUE、失敗時　FALSE
-		:返り値型:	bool
+		:returns:	成功時　TRUE、失敗時　FALSE
+		:rtype:	bool
 
 		このメソッドはキャッシュ全体をクリアします。もしキャッシュファイルの
 		削除に失敗した場合、このメソッドは FALSE を返します。
@@ -161,8 +161,8 @@ available in the hosting environment.
 
 	.. php:method:: cache_info()
 
-		:返り値:	全キャッシュ・データベースの情報
-		:返り値型:	mixed
+		:returns:	全キャッシュ・データベースの情報
+		:rtype:	mixed
 
 		このメソッドはキャッシュ全体の情報を返します。
 		::
@@ -174,9 +174,9 @@ available in the hosting environment.
 
 	.. php:method:: get_metadata($id)
 
-		:パラメータ	string	$id: キャッシュ・アイテム名
-		:返り値:	キャッシュアイテムのメタデータ
-		:返り値型:	mixed
+		:param	string	$id: キャッシュ・アイテム名
+		:returns:	キャッシュアイテムのメタデータ
+		:rtype:	mixed
 
 		このメソッドは、キャッシュの中の特定の1つのアイテムに
 		関する詳細な情報を返します。

--- a/source/libraries/calendar.rst
+++ b/source/libraries/calendar.rst
@@ -217,36 +217,36 @@ URL を指すリンクになります。
 
 	.. php:method:: initialize([$config = array()])
 
-		:パラメータ	array	$config: 構成パラメータ
-		:返り値:	    CI_Calendar インスタンス (メソッドチェーン)
-		:返り値型:	CI_Calendar
+		:param	array	$config: 構成パラメータ
+		:returns:	    CI_Calendar インスタンス (メソッドチェーン)
+		:rtype:	CI_Calendar
 
 		カレンダーの環境設定を初期化します。表示設定を含む入力として連想配列を受け入れます。
 
 	.. php:method:: generate([$year = ''[, $month = ''[, $data = array()]]])
 
-		:パラメータ	int	$year: 年
-		:パラメータ	int	$month: 月
-		:パラメータ	array	$data: カレンダーセルにデータを表示
-		:返り値:	    HTMLフォーマット カレンダー
-		:返り値型:	string
+		:param	int	$year: 年
+		:param	int	$month: 月
+		:param	array	$data: カレンダーセルにデータを表示
+		:returns:	    HTMLフォーマット カレンダー
+		:rtype:	string
 
 		カレンダーを生成
 
 
 	.. php:method:: get_month_name($month)
 
-		:パラメータ	int	$month: 月
-		:返り値:	    月名
-		:返り値型:	string
+		:param	int	$month: 月
+		:returns:	    月名
+		:rtype:	string
 
 		月の数値に基づいての月名を生成します。
 
 	.. php:method:: get_day_names($day_type = '')
 
-		:パラメータ	string	$day_type: 'long', 'short', or 'abr'
-		:返り値:	    Array of day names
-		:返り値型:	array
+		:param	string	$day_type: 'long', 'short', or 'abr'
+		:returns:	    Array of day names
+		:rtype:	array
 
 		型に基づき、曜日名（日曜日、月曜日、など）の配列を返します。
 		オプション：long, short, abr または なし ``$day_type``が提供
@@ -255,10 +255,10 @@ URL を指すリンクになります。
 
 	.. php:method:: adjust_date($month, $year)
 
-		:パラメータ	int	$month: 月
-		:パラメータ	int	$year: 年
-		:返り値:	    月と年を含む連想配列
-		:返り値型:	array
+		:param	int	$month: 月
+		:param	int	$year: 年
+		:returns:	    月と年を含む連想配列
+		:rtype:	array
 
 		この方法では、有効な月/年保持していることを確認します。
 		例えば月に13を提出した場合、年が増加すると月が1月
@@ -276,10 +276,10 @@ URL を指すリンクになります。
 
 	.. php:method:: get_total_days($month, $year)
 
-		:パラメータ	int	$month: 月
-		:パラメータ	int	$year: 年
-		:返り値:	    指定された月の日数カウント
-		:返り値型:	int
+		:param	int	$month: 月
+		:param	int	$year: 年
+		:returns:	    指定された月の日数カウント
+		:rtype:	int
 
 		指定された月の総日数::
 
@@ -291,8 +291,8 @@ URL を指すリンクになります。
 
 	.. php:method:: default_template()
 
-		:返り値:	    テンプレート値の配列
-		:返り値型:	array
+		:returns:	    テンプレート値の配列
+		:rtype:	array
 
 		デフォルトのテンプレートを設定します。このメソッドはあなたが作成していない
 		ときに使用される独自のテンプレートを返します。
@@ -300,8 +300,8 @@ URL を指すリンクになります。
 
 	.. php:method:: parse_template()
 
-		:返り値:	CI_Calendar インスタンス (メソッドチェーン)
-		:返り値型:	CI_Calendar
+		:returns:	CI_Calendar インスタンス (メソッドチェーン)
+		:rtype:	CI_Calendar
 
 		テンプレート内のデータを収集
 		``{疑似変数}``カレンダーを表示するために使用されます。

--- a/source/libraries/cart.rst
+++ b/source/libraries/cart.rst
@@ -304,9 +304,9 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: insert([$items = array()])
 
-		:パラメータ	array	$items: カートに挿入する項目
-		:返り値:	    成功時　TRUE  失敗時　FALSE
-		:返り値型:	bool
+		:param	array	$items: カートに挿入する項目
+		:returns:	    成功時　TRUE  失敗時　FALSE
+		:rtype:	bool
 
 		カートに項目を挿入しセッションテーブルに保存します。
 		成功時TRUE、失敗した場合FALSEを返します
@@ -314,9 +314,9 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: update([$items = array()])
 
-		:パラメータ	array	$items: カートのアイテムを更新する
-		:返り値:	    成功時　TRUE、失敗時　FALSE
-		:返り値型:	bool
+		:param	array	$items: カートのアイテムを更新する
+		:returns:	    成功時　TRUE、失敗時　FALSE
+		:rtype:	bool
 
 		このメソッドは、指定された項目のプロパティを変更することが可能です。
 		数量の変更を加える場合、通常チェックアウトの前に「カートを見る」ページ
@@ -325,34 +325,34 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: remove($rowid)
 
-		:パラメータ	int	$rowid: アイテムのIDをショッピングカートから削除する
-		:返り値:	成功時　TRUE、失敗時　FALSE
-		:返り値型:	bool
+		:param	int	$rowid: アイテムのIDをショッピングカートから削除する
+		:returns:	成功時　TRUE、失敗時　FALSE
+		:rtype:	bool
 
 		`` $rowid``を渡すことでショッピングカートからアイテムを削除すること
 		ができます。
 
 	.. php:method:: total()
 
-		:返り値:	合計金額
-		:返り値型:	int
+		:returns:	合計金額
+		:rtype:	int
 
 		カート内の合計金額が表示されます。
 
 
 	.. php:method:: total_items()
 
-		:返り値:	カート内のアイテムの合計額
-		:返り値型:	int
+		:returns:	カート内のアイテムの合計額
+		:rtype:	int
 
 		カート内のアイテムの合計数を表示します。
 
 
 	.. php:method:: contents([$newest_first = FALSE])
 
-		:パラメータ	bool	$newest_first: Whether to order the array with newest items first
-		:返り値:	    An array of cart contents
-		:返り値型:	array
+		:param	bool	$newest_first: Whether to order the array with newest items first
+		:returns:	    An array of cart contents
+		:rtype:	array
 
 		カート内のすべてのものを含む配列を返します。
 		あなたは返された配列、新から旧へまたは
@@ -361,18 +361,18 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: get_item($row_id)
 
-		:パラメータ	int	$row_id: Row ID の所得
-		:返り値:	アイテムデータの配列
-		:返り値型:	array
+		:param	int	$row_id: Row ID の所得
+		:returns:	アイテムデータの配列
+		:rtype:	array
 
 		指定された行のIDと一致する項目の配列を含むデータを返し、
 		またはそのような項目が存在しない場合はFALSEを返します。
 
 	.. php:method:: has_options($row_id = '')
 
-		:パラメータ	int	$row_id: Row ID の検査
-		:返り値:	オプションが存在する場合TRUE、それ以外の場合はFALSE
-		:返り値型:	bool
+		:param	int	$row_id: Row ID の検査
+		:returns:	オプションが存在する場合TRUE、それ以外の場合はFALSE
+		:rtype:	bool
 
 		カート内の特定の行がオプションが含まれている場合はTRUE（ブール値）を返します。
 		このメソッドは、rowid を渡す必要があるので、カートを表示する の例
@@ -381,9 +381,9 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: product_options([$row_id = ''])
 
-		:パラメータ	int	$row_id: Row ID
-		:返り値:	    製品のオプションの配列
-		:返り値型:	array
+		:param	int	$row_id: Row ID
+		:returns:	    製品のオプションの配列
+		:rtype:	array
 
 		特定の商品のオプションの配列を返します。このメソッドは、r
 		owid を渡す必要があるので、カートを表示する の例で示すよう
@@ -392,7 +392,7 @@ row ID は、商品がカートに追加される際に、カートのコード
 
 	.. php:method:: destroy()
 
-		:返り値型: void
+		:rtype: void
 
 		カートを破棄します。
 		このメソッドは、顧客の注文が完了した際などに呼ばれます。

--- a/source/libraries/config.rst
+++ b/source/libraries/config.rst
@@ -184,44 +184,44 @@ NULLを返します。
 
 	.. php:method:: item($item[, $index=''])
 
-		:パラメータ	string	$item: Configの項目名
-		:パラメータ	string	$index: インデックス名
-		:返り値:	    Configの項目値、見つからない場合はNULL
-		:返り値型:	mixed
+		:param	string	$item: Configの項目名
+		:param	string	$index: インデックス名
+		:returns:	    Configの項目値、見つからない場合はNULL
+		:rtype:	mixed
 
 		設定ファイルの項目を取得します。
 
 	.. php:method:: set_item($item, $value)
 
-		:パラメータ	string	$item: Configの項目名
-		:パラメータ	string	$value: Configの項目値
-		:返り値型:	void
+		:param	string	$item: Configの項目名
+		:param	string	$value: Configの項目値
+		:rtype:	void
 
 		指定された値に設定ファイルの項目を設定します。
 
 	.. php:method:: slash_item($item)
 
-		:パラメータ	string	$item: Configの項目名
-		:返り値:	Configの項目フォワード末尾の値スラッシュ見つからない場合はnull
-		:返り値型:	mixed
+		:param	string	$item: Configの項目名
+		:returns:	Configの項目フォワード末尾の値スラッシュ見つからない場合はnull
+		:rtype:	mixed
 
 		この方法は、``item()``と同じです,  設定項目の末尾に
 		スラッシュを加えます。
 
 	.. php:method:: load([$file = ''[, $use_sections = FALSE[, $fail_gracefully = FALSE]]])
 
-		:パラメータ	string	$file: 構成ファイル名
-		:パラメータ	bool	$use_sections: 設定値　独自のセクションにロードする必要があるかどうか(主な構成配列のインデックス)
-		:パラメータ	bool	$fail_gracefully: falseを返す、またはエラーメッセージを表示するかどうか
-		:返り値:	    成功時　TRUE 失敗時　FALSE
-		:返り値型:	bool
+		:param	string	$file: 構成ファイル名
+		:param	bool	$use_sections: 設定値　独自のセクションにロードする必要があるかどうか(主な構成配列のインデックス)
+		:param	bool	$fail_gracefully: falseを返す、またはエラーメッセージを表示するかどうか
+		:returns:	    成功時　TRUE 失敗時　FALSE
+		:rtype:	bool
 
 		設定ファイルをロードします。
 
 	.. php:method:: site_url()
 
-		:返り値:	サイトURL
-		:返り値型:	string
+		:returns:	サイトURL
+		:rtype:	string
 
 		このメソッドは、設定ファイルで、"index" の値に指定した、
 		サイトへの URL を取得します。
@@ -231,8 +231,8 @@ NULLを返します。
 
 	.. php:method:: base_url()
 
-		:返り値:	    ベース URL
-		:返り値型:	string
+		:returns:	    ベース URL
+		:rtype:	string
 
 		このメソッドは、サイトの URL、プラス、オプションの
 		スタイルシートや画像などへのパスを取得します。
@@ -242,8 +242,8 @@ NULLを返します。
 
 	.. php:method:: system_url()
 
-		:返り値:	CI system/ フォルダの指しているURL
-		:返り値型:	string
+		:returns:	CI system/ フォルダの指しているURL
+		:rtype:	string
 
 		このメソッドを使うと system フォルダ の URL を取得できます。
 

--- a/source/libraries/email.rst
+++ b/source/libraries/email.rst
@@ -145,11 +145,11 @@ Email クラスの設定項目
 
 	.. php:method:: from($from[, $name = ''[, $return_path = NULL]])
 
-		:パラメータ	string	$from: "From" メールアドレス
-		:パラメータ	string	$name: "From" 表示名
-		:パラメータ	string	$return_path: 未配達の電子メールをリダイレクトするオプションのメールアドレス
-		:返り値:	CI_Email インスタンス (メソッドチエーン)
-		:返り値型:	CI_Email
+		:param	string	$from: "From" メールアドレス
+		:param	string	$name: "From" 表示名
+		:param	string	$return_path: 未配達の電子メールをリダイレクトするオプションのメールアドレス
+		:returns:	CI_Email インスタンス (メソッドチエーン)
+		:rtype:	CI_Email
 
 		電子メール送信者の電子メールアドレスと氏名をセットします::
 
@@ -164,10 +164,10 @@ Email クラスの設定項目
 
 	.. php:method:: reply_to($replyto[, $name = ''])
 
-		:パラメータ	string	$replyto: 返信の電子メール・アドレス
-		:パラメータ	string	$name: 返信の電子メールアドレス名を示します
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	string	$replyto: 返信の電子メール・アドレス
+		:param	string	$name: 返信の電子メールアドレス名を示します
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		返信先アドレスをセットします。指定しない場合は、"from" メソッド
 		で指定されたものが使われます。例:
@@ -176,9 +176,9 @@ Email クラスの設定項目
 
 	.. php:method:: to($to)
 
-		:パラメータ	mixed	$to: メールアドレス　カンマで区切られた列または配列
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	mixed	$to: メールアドレス　カンマで区切られた列または配列
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		受取人のメールアドレスをセットします(複数可)。次のように、単一のメールアドレス、
 		カンマ区切りのリスト、あるいは配列で指定可能です:
@@ -197,19 +197,19 @@ Email クラスの設定項目
 
 	.. php:method:: cc($cc)
 
-		:パラメータ	mixed	$cc: メールアドレス　カンマで区切られた列または配列
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	mixed	$cc: メールアドレス　カンマで区切られた列または配列
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		CC のメールアドレスをセットします(複数可)。 "to" メソッドのように、単一のメールアドレス、
 		カンマ区切りのリスト、あるいは配列で指定可能です。
 
 	.. php:method:: bcc($bcc[, $limit = ''])
 
-		:パラメータ	mixed	$bcc: メールアドレス　カンマで区切られた列または配列
-		:パラメータ	int	$limit: バッチ送信する電子メールの最大数
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	mixed	$bcc: メールアドレス　カンマで区切られた列または配列
+		:param	int	$limit: バッチ送信する電子メールの最大数
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		BCC のメールアドレスをセットします(複数可)。"to" メソッドのように、単一のメールアドレス、
 		ンマ区切りのリスト、あるいは配列で指定可能です。
@@ -220,9 +220,9 @@ Email クラスの設定項目
 
 	.. php:method:: subject($subject)
 
-		:パラメータ	string	$subject: 電子メールの件名
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	string	$subject: 電子メールの件名
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		電子メールの件名をセットします::
 
@@ -230,9 +230,9 @@ Email クラスの設定項目
 
 	.. php:method:: message($body)
 
-		:パラメータ	string	$body: 電子メール本文
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	string	$body: 電子メール本文
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		電子メールの本文をセットします::
 
@@ -240,9 +240,9 @@ Email クラスの設定項目
 
 	.. php:method:: set_alt_message($str)
 
-		:パラメータ	string	$str: 代替のメール本文:
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	string	$str: 代替のメール本文:
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		代替のメール本文をセットします::
 
@@ -257,10 +257,10 @@ Email クラスの設定項目
 
 	.. php:method:: set_header($header, $value)
 
-		:パラメータ	string	$header: ヘッダ名
-		:パラメータ	string	$value: ヘッダ内容
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型: CI_Email
+		:param	string	$header: ヘッダ名
+		:param	string	$value: ヘッダ内容
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype: CI_Email
 
 		電子メールの追加のヘッダーを付加::
 
@@ -269,9 +269,9 @@ Email クラスの設定項目
 
 	.. php:method:: clear([$clear_attachments = FALSE])
 
-		:パラメータ	bool	$clear_attachments: 添付ファイルをクリアするかどうか
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型: CI_Email
+		:param	bool	$clear_attachments: 添付ファイルをクリアするかどうか
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype: CI_Email
 
 		メールの設定を空状態にします。 このメソッドは、ループの
 		各サイクルでデータをリセットしながらメール送信機能を使う
@@ -297,9 +297,9 @@ Email クラスの設定項目
 
 	.. php:method:: send([$auto_clear = TRUE])
 
-		:パラメータ	bool	$auto_clear: 自動的にメッセージデータをクリアするかどうか
-		:返り値:	成功時TRUE、失敗した場合FALSE
-		:返り値型:	bool
+		:param	bool	$auto_clear: 自動的にメッセージデータをクリアするかどうか
+		:returns:	成功時TRUE、失敗した場合FALSE
+		:rtype:	bool
 
 		メール送信メソッド。 条件判断が利用できるよう、送信が成功したか失敗したかに
 		基づいてブール値の TRUE か FALSE が返ります::
@@ -322,14 +322,14 @@ Email クラスの設定項目
 
 	.. php:method:: attach($filename[, $disposition = ''[, $newname = NULL[, $mime = '']]])
 
-		:パラメータ	string	$filename: ファイル名
-		:パラメータ	string	$disposition: 添付ファイルを「配置」します。ほとんどの電子メールクライアント
+		:param	string	$filename: ファイル名
+		:param	string	$disposition: 添付ファイルを「配置」します。ほとんどの電子メールクライアント
 		にかかわらず、ここで使用されるMIME仕様の独自の判断を下します。
 		https://www.iana.org/assignments/cont-disp/cont-disp.xhtml
-		:パラメータ	string	$newname: 電子メールで使用するカスタムファイル名
-		:パラメータ	string	$mime: MIMEタイプを使用する (バッファリングされたデータに利用)
-		:返り値:	CI_Email インスタンス (メソッドチェイン)
-		:返り値型:	CI_Email
+		:param	string	$newname: 電子メールで使用するカスタムファイル名
+		:param	string	$mime: MIMEタイプを使用する (バッファリングされたデータに利用)
+		:returns:	CI_Email インスタンス (メソッドチェイン)
+		:rtype:	CI_Email
 
 		添付ファイルを送信できます。第1引数にファイルのパスとファイル名を指定してください。
 		複数ファイルを添付する場合は、複数回メソッドを呼んでください。例えば以下のように
@@ -360,9 +360,9 @@ Email クラスの設定項目
 
 	.. php:method:: attachment_cid($filename)
 
-		:パラメータ	string	$filename: 既存の添付ファイル名
-		:返り値:	添付ファイルのContent-ID、見つからない場合はFALSE
-		:返り値型:	string
+		:param	string	$filename: 既存の添付ファイル名
+		:returns:	添付ファイルのContent-ID、見つからない場合はFALSE
+		:rtype:	string
  
 		添付ファイルのセットとContent-IDを返し、添付ファイルをHTMLにインライン（写真）埋め込むため有効にします。
 		最初のパラメータは、すでに添付されたファイル名でなければなりません。
@@ -382,9 +382,9 @@ Email クラスの設定項目
 
 	.. php:method:: print_debugger([$include = array('headers', 'subject', 'body')])
 
-		:パラメータ	array	$include: メッセージのどの部分を印刷するか
-		:返り値:	フォーマットされたデバッグデータ
-		:返り値型:	string
+		:param	array	$include: メッセージのどの部分を印刷するか
+		:returns:	フォーマットされたデバッグデータ
+		:rtype:	string
 
 		すべてのサーバメッセージ、メールヘッダ、メールメッセージを文字列として返します。
 		デバッグに役立ちます。

--- a/source/libraries/form_validation.rst
+++ b/source/libraries/form_validation.rst
@@ -1030,11 +1030,11 @@ to use:
 
 	.. php:method:: set_rules($field[, $label = ''[, $rules = '']])
 
-		:パラメータ	string	$field: Field name
-		:パラメータ	string	$label: Field label
-		:パラメータ	mixed	$rules: Validation rules, as a string list separated by a pipe "|", or as an array or rules
-		:返り値:	CI_Form_validation instance (method chaining)
-		:返り値型:	CI_Form_validation
+		:param	string	$field: Field name
+		:param	string	$label: Field label
+		:param	mixed	$rules: Validation rules, as a string list separated by a pipe "|", or as an array or rules
+		:returns:	CI_Form_validation instance (method chaining)
+		:rtype:	CI_Form_validation
 
 		Permits you to set validation rules, as described in the tutorial
 		sections above:
@@ -1044,9 +1044,9 @@ to use:
 
 	.. php:method:: run([$group = ''])
 
-		:パラメータ	string	$group: The name of the validation group to run
-		:返り値:	    TRUE on success, FALSE if validation failed
-		:返り値型:	bool
+		:param	string	$group: The name of the validation group to run
+		:returns:	    TRUE on success, FALSE if validation failed
+		:rtype:	bool
 
 		Runs the validation routines. Returns boolean TRUE on success and FALSE
 		on failure. You can optionally pass the name of the validation group via
@@ -1054,72 +1054,72 @@ to use:
 
 	.. php:method:: set_message($lang[, $val = ''])
 
-		:パラメータ	string	$lang: The rule the message is for
-		:パラメータ	string	$val: The message
-		:返り値:	CI_Form_validation instance (method chaining)
-		:返り値型:	CI_Form_validation
+		:param	string	$lang: The rule the message is for
+		:param	string	$val: The message
+		:returns:	CI_Form_validation instance (method chaining)
+		:rtype:	CI_Form_validation
 
 		Permits you to set custom error messages. See :ref:`setting-error-messages`
 
 	.. php:method:: set_error_delimiters([$prefix = '<p>'[, $suffix = '</p>']])
 
-		:パラメータ	string	$prefix: Error message prefix
-		:パラメータ	string	$suffix: Error message suffix
-		:返り値:	CI_Form_validation instance (method chaining)
-		:返り値型:	CI_Form_validation
+		:param	string	$prefix: Error message prefix
+		:param	string	$suffix: Error message suffix
+		:returns:	CI_Form_validation instance (method chaining)
+		:rtype:	CI_Form_validation
 
 		Sets the default prefix and suffix for error messages.
 
 	.. php:method:: set_data($data)
 
-		:パラメータ	array	$data: Array of data validate
-		:返り値:  	CI_Form_validation instance (method chaining)
-		:返り値型:	CI_Form_validation
+		:param	array	$data: Array of data validate
+		:returns:  	CI_Form_validation instance (method chaining)
+		:rtype:	CI_Form_validation
 
 		Permits you to set an array for validation, instead of using the default
 		``$_POST`` array.
 
 	.. php:method:: reset_validation()
 
-		:返り値:	CI_Form_validation instance (method chaining)
-		:返り値型:	CI_Form_validation
+		:returns:	CI_Form_validation instance (method chaining)
+		:rtype:	CI_Form_validation
 
 		Permits you to reset the validation when you validate more than one array.
 		This method should be called before validating each new array.
 
 	.. php:method:: error_array()
 
-		:返り値:	Array of error messages
-		:返り値型:	array
+		:returns:	Array of error messages
+		:rtype:	array
 
 		Returns the error messages as an array.
 
 	.. php:method:: error_string([$prefix = ''[, $suffix = '']])
 
-		:パラメータ	string	$prefix: Error message prefix
-		:パラメータ	string	$suffix: Error message suffix
-		:返り値:	Error messages as a string
-		:返り値型:	string
+		:param	string	$prefix: Error message prefix
+		:param	string	$suffix: Error message suffix
+		:returns:	Error messages as a string
+		:rtype:	string
 
 		Returns all error messages (as returned from error_array()) formatted as a
 		string and separated by a newline character.
 
 	.. php:method:: error($field[, $prefix = ''[, $suffix = '']])
 
-		:パラメータ	string $field: Field name
-		:パラメータ	string $prefix: Optional prefix
-		:パラメータ	string $suffix: Optional suffix
-		:返り値:	Error message string
-		:返り値型:	string
+		:param	string $field: Field name
+		:param	string $prefix: Optional prefix
+		:param	string $suffix: Optional suffix
+		:returns:	Error message string
+		:rtype:	string
 
 		Returns the error message for a specific field, optionally adding a
 		prefix and/or suffix to it (usually HTML tags).
 
 	.. php:method:: has_rule($field)
 
-		:パラメータ	string	$field: Field name
-		:返り値:	TRUE if the field has rules set, FALSE if not
-		:返り値型:	bool
+		:param	string	$field: Field name
+		:returns:	TRUE if the field has rules set, FALSE if not
+		:rtype:	bool
 
 		Checks to see if there is a rule set for the specified field.
 

--- a/source/libraries/ftp.rst
+++ b/source/libraries/ftp.rst
@@ -94,9 +94,9 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: connect([$config = array()])
 
-		:パラメータ	array	$config: Connection values
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	array	$config: Connection values
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Connects and logs into to the FTP server. Connection preferences are set
 		by passing an array to the function, or you can store them in a config
@@ -137,12 +137,12 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: upload($locpath, $rempath[, $mode = 'auto'[, $permissions = NULL]])
 
-		:パラメータ	string	$locpath: Local file path
-		:パラメータ	string	$rempath: Remote file path
-		:パラメータ	string	$mode: FTP mode, defaults to 'auto' (options are: 'auto', 'binary', 'ascii')
-		:パラメータ	int	$permissions: File permissions (octal)
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$locpath: Local file path
+		:param	string	$rempath: Remote file path
+		:param	string	$mode: FTP mode, defaults to 'auto' (options are: 'auto', 'binary', 'ascii')
+		:param	int	$permissions: File permissions (octal)
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Uploads a file to your server. You must supply the local path and the
 		remote path, and you can optionally set the mode and permissions.
@@ -156,11 +156,11 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: download($rempath, $locpath[, $mode = 'auto'])
 
-		:パラメータ	string	$rempath: Remote file path
-		:パラメータ	string	$locpath: Local file path
-		:パラメータ	string	$mode: FTP mode, defaults to 'auto' (options are: 'auto', 'binary', 'ascii')
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$rempath: Remote file path
+		:param	string	$locpath: Local file path
+		:param	string	$mode: FTP mode, defaults to 'auto' (options are: 'auto', 'binary', 'ascii')
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Downloads a file from your server. You must supply the remote path and
 		the local path, and you can optionally set the mode. Example::
@@ -174,11 +174,11 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: rename($old_file, $new_file[, $move = FALSE])
 
-		:パラメータ	string	$old_file: Old file name
-		:パラメータ	string	$new_file: New file name
-		:パラメータ	bool	$move: Whether a move is being performed
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$old_file: Old file name
+		:param	string	$new_file: New file name
+		:param	bool	$move: Whether a move is being performed
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Permits you to rename a file. Supply the source file name/path and the new file name/path.
 		::
@@ -188,10 +188,10 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: move($old_file, $new_file)
 
-		:パラメータ	string	$old_file: Old file name
-		:パラメータ	string	$new_file: New file name
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$old_file: Old file name
+		:param	string	$new_file: New file name
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Lets you move a file. Supply the source and destination paths::
 
@@ -202,9 +202,9 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: delete_file($filepath)
 
-		:パラメータ	string	$filepath: Path to file to delete
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$filepath: Path to file to delete
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Lets you delete a file. Supply the source path with the file name.
 		::
@@ -213,9 +213,9 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: delete_dir($filepath)
 
-		:パラメータ	string	$filepath: Path to directory to delete
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$filepath: Path to directory to delete
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Lets you delete a directory and everything it contains. Supply the
 		source path to the directory with a trailing slash.
@@ -231,9 +231,9 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: list_files([$path = '.'])
 
-		:パラメータ	string	$path: Directory path
-		:返り値:	An array list of files or FALSE on failure
-		:返り値型:	array
+		:param	string	$path: Directory path
+		:returns:	An array list of files or FALSE on failure
+		:rtype:	array
 
 		Permits you to retrieve a list of files on your server returned as an
 		array. You must supply the path to the desired directory.
@@ -244,10 +244,10 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: mirror($locpath, $rempath)
 
-		:パラメータ	string	$locpath: Local path
-		:パラメータ	string	$rempath: Remote path
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$locpath: Local path
+		:param	string	$rempath: Remote path
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Recursively reads a local folder and everything it contains (including
 		sub-folders) and creates a mirror via FTP based on it. Whatever the
@@ -258,10 +258,10 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: mkdir($path[, $permissions = NULL])
 
-		:パラメータ	string	$path: Path to directory to create
-		:パラメータ	int	$permissions: Permissions (octal)
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$path: Path to directory to create
+		:param	int	$permissions: Permissions (octal)
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Lets you create a directory on your server. Supply the path ending in
 		the folder name you wish to create, with a trailing slash.
@@ -274,10 +274,10 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: chmod($path, $perm)
 
-		:パラメータ	string	$path: Path to alter permissions for
-		:パラメータ	int	$perm: Permissions (octal)
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$path: Path to alter permissions for
+		:param	int	$perm: Permissions (octal)
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Permits you to set file permissions. Supply the path to the file or
 		directory you wish to alter permissions on::
@@ -287,10 +287,10 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: changedir($path[, $suppress_debug = FALSE])
 
-		:パラメータ	string	$path: Directory path
-		:パラメータ	bool	$suppress_debug: Whether to turn off debug messages for this command
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:param	string	$path: Directory path
+		:param	bool	$suppress_debug: Whether to turn off debug messages for this command
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Changes the current working directory to the specified path.
 
@@ -299,8 +299,8 @@ In this example a local directory is mirrored on the server.
 
 	.. php:method:: close()
 
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Closes the connection to your server. It's recommended that you use this
 		when you are finished uploading.

--- a/source/libraries/image_lib.rst
+++ b/source/libraries/image_lib.rst
@@ -321,16 +321,16 @@ of watermarking.
 
 	.. php:method:: initialize([$props = array()])
 
-		:パラメータ	array	$props: Image processing preferences
-		:返り値:	TRUE on success, FALSE in case of invalid settings
-		:返り値型:	bool
+		:param	array	$props: Image processing preferences
+		:returns:	TRUE on success, FALSE in case of invalid settings
+		:rtype:	bool
 
 		Initializes the class for processing an image.
 
 	.. php:method:: resize()
 
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		The image resizing method lets you resize the original image, create a
 		copy (with or without resizing), or create a thumbnail image.
@@ -376,8 +376,8 @@ of watermarking.
 
 	.. php:method:: crop()
 
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		The cropping method works nearly identically to the resizing function
 		except it requires that you set preferences for the X and Y axis (in
@@ -412,8 +412,8 @@ of watermarking.
 
 	.. php:method:: rotate()
 
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		The image rotation method requires that the angle of rotation be set
 		via its preference::
@@ -444,15 +444,15 @@ of watermarking.
 
 	.. php:method:: watermark()
 
-		:返り値:	TRUE on success, FALSE on failure
-		:返り値型:	bool
+		:returns:	TRUE on success, FALSE on failure
+		:rtype:	bool
 
 		Creates a watermark over an image, please refer to the :ref:`watermarking`
 		section for more info.		
 
 	.. php:method:: clear()
 
-		:返り値:	void
+		:returns:	void
 
 		The clear method resets all of the values used when processing an
 		image. You will want to call this if you are processing images in a
@@ -464,10 +464,10 @@ of watermarking.
 
 	.. php:method:: display_errors([$open = '<p>[, $close = '</p>']])
 
-		:パラメータ	string	$open: Error message opening tag
-		:パラメータ	string	$close: Error message closing tag
-		:返り値:	Error messages
-		:返り値型:	string
+		:param	string	$open: Error message opening tag
+		:param	string	$close: Error message closing tag
+		:returns:	Error messages
+		:rtype:	string
 
 		Returns all detected errors formatted as a string.
 		::

--- a/source/libraries/input.rst
+++ b/source/libraries/input.rst
@@ -175,10 +175,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: get([$index = NULL[, $xss_clean = NULL]])
 
-		:パラメータ	mixed	$index: GET parameter name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	$_GET if no parameters supplied, otherwise the GET value if found or NULL if not
-		:返り値型:	mixed
+		:param	mixed	$index: GET parameter name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	$_GET if no parameters supplied, otherwise the GET value if found or NULL if not
+		:rtype:	mixed
 
 		This method is identical to ``post()``, only it fetches GET data.
 		::
@@ -208,10 +208,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: post_get($index[, $xss_clean = NULL])
 
-		:パラメータ	string	$index: POST/GET parameter name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	POST/GET value if found, NULL if not
-		:返り値型:	mixed
+		:param	string	$index: POST/GET parameter name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	POST/GET value if found, NULL if not
+		:rtype:	mixed
 
 		This method works pretty much the same way as ``post()`` and ``get()``,
 		only combined. It will search through both POST and GET streams for data,
@@ -221,10 +221,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: get_post($index[, $xss_clean = NULL])
 
-		:パラメータ	string	$index: GET/POST parameter name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	GET/POST value if found, NULL if not
-		:返り値型:	mixed
+		:param	string	$index: GET/POST parameter name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	GET/POST value if found, NULL if not
+		:rtype:	mixed
 
 		This method works the same way as ``post_get()`` only it looks for GET
 		data first.
@@ -236,10 +236,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: cookie([$index = NULL[, $xss_clean = NULL]])
 
-		:パラメータ	mixed	$index: COOKIE name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	$_COOKIE if no parameters supplied, otherwise the COOKIE value if found or NULL if not
-		:返り値型:	mixed
+		:param	mixed	$index: COOKIE name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	$_COOKIE if no parameters supplied, otherwise the COOKIE value if found or NULL if not
+		:rtype:	mixed
 
 		This method is identical to ``post()`` and ``get()``, only it fetches cookie
 		data::
@@ -259,10 +259,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: server($index[, $xss_clean = NULL])
 
-		:パラメータ	mixed	$index: Value name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	$_SERVER item value if found, NULL if not
-		:返り値型:	mixed
+		:param	mixed	$index: Value name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	$_SERVER item value if found, NULL if not
+		:rtype:	mixed
 
 		This method is identical to the ``post()``, ``get()`` and ``cookie()``
 		methods, only it fetches server data (``$_SERVER``)::
@@ -277,25 +277,25 @@ a boolean value as the second parameter::
 
 	.. php:method:: input_stream([$index = NULL[, $xss_clean = NULL]])
 
-		:パラメータ	mixed	$index: Key name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	Input stream array if no parameters supplied, otherwise the specified value if found or NULL if not
-		:返り値型:	mixed
+		:param	mixed	$index: Key name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	Input stream array if no parameters supplied, otherwise the specified value if found or NULL if not
+		:rtype:	mixed
 
 		This method is identical to ``get()``, ``post()`` and ``cookie()``,
 		only it fetches the *php://input* stream data.
 
 	.. php:method:: set_cookie($name = ''[, $value = ''[, $expire = ''[, $domain = ''[, $path = '/'[, $prefix = ''[, $secure = FALSE[, $httponly = FALSE]]]]]]])
 
-		:パラメータ	mixed	$name: Cookie name or an array of parameters
-		:パラメータ	string	$value: Cookie value
-		:パラメータ	int	$expire: Cookie expiration time in seconds
-		:パラメータ	string	$domain: Cookie domain
-		:パラメータ	string	$path: Cookie path
-		:パラメータ	string	$prefix: Cookie name prefix
-		:パラメータ	bool	$secure: Whether to only transfer the cookie through HTTPS
-		:パラメータ	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
-		:返り値型:	void
+		:param	mixed	$name: Cookie name or an array of parameters
+		:param	string	$value: Cookie value
+		:param	int	$expire: Cookie expiration time in seconds
+		:param	string	$domain: Cookie domain
+		:param	string	$path: Cookie path
+		:param	string	$prefix: Cookie name prefix
+		:param	bool	$secure: Whether to only transfer the cookie through HTTPS
+		:param	bool	$httponly: Whether to only make the cookie accessible for HTTP requests (no JavaScript)
+		:rtype:	void
 
 
 		Sets a cookie containing the values you specify. There are two ways to
@@ -350,8 +350,8 @@ a boolean value as the second parameter::
 
 	.. php:method:: ip_address()
 
-		:返り値:	Visitor's IP address or '0.0.0.0' if not valid
-		:返り値型:	string
+		:returns:	Visitor's IP address or '0.0.0.0' if not valid
+		:rtype:	string
 
 		Returns the IP address for the current user. If the IP address is not
 		valid, the method will return '0.0.0.0'::
@@ -365,10 +365,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: valid_ip($ip[, $which = ''])
 
-		:パラメータ	string	$ip: IP address
-		:パラメータ	string	$which: IP protocol ('ipv4' or 'ipv6')
-		:返り値:	TRUE if the address is valid, FALSE if not
-		:返り値型:	bool
+		:param	string	$ip: IP address
+		:param	string	$which: IP protocol ('ipv4' or 'ipv6')
+		:returns:	TRUE if the address is valid, FALSE if not
+		:rtype:	bool
 
 		Takes an IP address as input and returns TRUE or FALSE (boolean) depending
 		on whether it is valid or not.
@@ -392,9 +392,9 @@ a boolean value as the second parameter::
 
 	.. php:method:: user_agent([$xss_clean = NULL])
 
-		:返り値:	User agent string or NULL if not set
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値型:	mixed
+		:returns:	User agent string or NULL if not set
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:rtype:	mixed
 
 		Returns the user agent string (web browser) being used by the current user,
 		or NULL if it's not available.
@@ -407,9 +407,9 @@ a boolean value as the second parameter::
 
 	.. php:method:: request_headers([$xss_clean = FALSE])
 
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	An array of HTTP request headers
-		:返り値型:	array
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	An array of HTTP request headers
+		:rtype:	array
 
 		Returns an array of HTTP request headers.
 		Useful if running in a non-Apache environment where
@@ -421,10 +421,10 @@ a boolean value as the second parameter::
 
 	.. php:method:: get_request_header($index[, $xss_clean = FALSE])
 
-		:パラメータ	string	$index: HTTP request header name
-		:パラメータ	bool	$xss_clean: Whether to apply XSS filtering
-		:返り値:	    An HTTP request header or NULL if not found
-		:返り値型:	string
+		:param	string	$index: HTTP request header name
+		:param	bool	$xss_clean: Whether to apply XSS filtering
+		:returns:	    An HTTP request header or NULL if not found
+		:rtype:	string
 
 		Returns a single member of the request headers array or NULL
 		if the searched header is not found.
@@ -434,16 +434,16 @@ a boolean value as the second parameter::
 
 	.. php:method:: is_ajax_request()
 
-		:返り値:	TRUE if it is an Ajax request, FALSE if not
-		:返り値型:	bool
+		:returns:	TRUE if it is an Ajax request, FALSE if not
+		:rtype:	bool
 
 		Checks to see if the HTTP_X_REQUESTED_WITH server header has been
 		set, and returns boolean TRUE if it is or FALSE if not.
 
 	.. php:method:: is_cli_request()
 
-		:返り値:	TRUE if it is a CLI request, FALSE if not
-		:返り値型:	bool
+		:returns:	TRUE if it is a CLI request, FALSE if not
+		:rtype:	bool
 
 		Checks to see if the application was run from the command-line
 		interface.
@@ -461,9 +461,9 @@ a boolean value as the second parameter::
 
 	.. php:method:: method([$upper = FALSE])
 
-		:パラメータ	bool	$upper: Whether to return the request method name in upper or lower case
-		:返り値:	    HTTP request method
-		:返り値型:	string
+		:param	bool	$upper: Whether to return the request method name in upper or lower case
+		:returns:	    HTTP request method
+		:rtype:	string
 
 		Returns the ``$_SERVER['REQUEST_METHOD']``, with the option to set it
 		in uppercase or lowercase.

--- a/source/libraries/zip.rst
+++ b/source/libraries/zip.rst
@@ -63,9 +63,9 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: add_data($filepath[, $data = NULL])
 
-		:パラメータ	mixed	$filepath: 一つのファイル経路または多数のファイル => 配列
-		:パラメータ	array	$data: ファイルのデータ ($filepath が配列であれば無視されます)
-		:返り値型:	void
+		:param	mixed	$filepath: 一つのファイル経路または多数のファイル => 配列
+		:param	array	$data: ファイルのデータ ($filepath が配列であれば無視されます)
+		:rtype:	void
 
 		Zipアーカイブにデータを追加できます。単独と複数のファイルモードで動作します。
 
@@ -102,8 +102,8 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: add_dir($directory)
 
-		:パラメータ	mixed	$directory: ディレクトリ名　文字列　または　配列
-		:返り値型:	void
+		:param	mixed	$directory: ディレクトリ名　文字列　または　配列
+		:rtype:	void
 
 		ディレクトリを追加できます。$this->zip->add_data() を使った時にデータをフォルダに追加
 		できるので、通常はこのメソッドは必要ないですが、空のフォルダを作成したい場合は、
@@ -113,10 +113,10 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: read_file($path[, $archive_filepath = FALSE])
 
-		:パラメータ	string	$path: ファイルのパス
-		:パラメータ	mixed	$archive_filepath: 新ファイル名/パス (string) または (boolean) オリジナルのファイルパス
-		:返り値:	維持したい場合　TRUE , 維持しない場合　FALSE
-		:返り値型:	bool
+		:param	string	$path: ファイルのパス
+		:param	mixed	$archive_filepath: 新ファイル名/パス (string) または (boolean) オリジナルのファイルパス
+		:returns:	維持したい場合　TRUE , 維持しない場合　FALSE
+		:rtype:	bool
 
 		サーバ上に既に存在しているフォルダ (およびその中身) を圧縮できます。ディレクトまでのパスを指定すると、Zipクラスは、再帰的にその
 		フォルダを読み込み、Zipファイルとして再作成します。指定されたパスに含まれるサブフォルダの配下にあるものも含めてすべてのファイルが圧縮されます。
@@ -152,11 +152,11 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: read_dir($path[, $preserve_filepath = TRUE[, $root_path = NULL]])
 
-		:パラメータ	string	$path: ファイルのパス
-		:パラメータ	bool	$preserve_filepath: オリジナルのファイルパス
-		:パラメータ	string	$root_path: アーカイブディレクトリから除外するパスの一部
-		:返り値:	維持したい場合　TRUE, 維持しない場合　FALSE
-		:返り値型:	bool
+		:param	string	$path: ファイルのパス
+		:param	bool	$preserve_filepath: オリジナルのファイルパス
+		:param	string	$root_path: アーカイブディレクトリから除外するパスの一部
+		:returns:	維持したい場合　TRUE, 維持しない場合　FALSE
+		:rtype:	bool
 
 		サーバ上に既に存在しているフォルダ (およびその中身) を圧縮できます。ディレクトまでのパスを指定すると、
 		Zipクラスは、再帰的にそのフォルダを読み込み、Zipファイルとして再作成します。指定されたパスに含まれる
@@ -182,9 +182,9 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: archive($filepath)
 
-		:パラメータ	string	$filepath: パスはZIPアーカイブを対象とします。
-		:返り値:	成功するとTRUE, 失敗するとFALSE を返します。
-		:返り値型:	bool
+		:param	string	$filepath: パスはZIPアーカイブを対象とします。
+		:returns:	成功するとTRUE, 失敗するとFALSE を返します。
+		:rtype:	bool
 
 		Zip 圧縮ファイルをサーバ上のディレクトリに書き込みます。ファイル名で終わる正しいサーバのパスを
 		渡します。 ディレクトリが書き込み可能(755であれば通常は大丈夫です)かどうかを確かめてください。
@@ -194,8 +194,8 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: download($filename = 'backup.zip')
 
-		:パラメータ	string	$filename: アーカイブ　ファイル名
-		:返り値型:	void
+		:param	string	$filename: アーカイブ　ファイル名
+		:rtype:	void
 
 		サーバから Zip ファイルをダウンロードさせます。このメソッドは、
 		Zip ファイルにつけたい名前を指定する必要があります。 例::
@@ -208,8 +208,8 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: get_zip()
 
-		:パラメータ:	ZIPファイル実体
-		:返り値型:	string
+		:param:	ZIPファイル実体
+		:rtype:	string
 
 		Zip 圧縮データを返します。データを使って何か特別な事をしない限りは、通常はこのメソッドは
 		必要ではありません。 例:
@@ -223,7 +223,7 @@ CodeIgniter の大部分のクラスと同様に、Zip クラスはコントロ�
 
 	.. php:method:: clear_data()
 
-		:返り値型: void
+		:rtype: void
 
 		Zip クラスは、上のメソッドを使うたびにZipアーカイブを再圧縮しなくて済むように、Zipデータを
 		キャッシュします。 しかし、それぞれ異なるデータの複数のZipを作成する場合、それらのメソッド


### PR DESCRIPTION
CI3 より method のパラメータや戻り値についても
ヘルプ内に記載されるようになりました。
そのため library などでは以下のように個別に翻訳しているようですが
パラメータのところで出力されるHTMLに違いが出てしまっています。
:param -> :パラメータ
:returns: ->  :返り値:
:rtype: -> :返り値型:


PR前の状態：
![before](https://cloud.githubusercontent.com/assets/121045/15266937/b14ad2fa-19ee-11e6-9585-59859c7ca36b.png)

PR後の状態：
![after](https://cloud.githubusercontent.com/assets/121045/15266939/b4ed2a7a-19ee-11e6-9b34-3c953ae8d7d3.png)

英語バージョン：
![english](https://cloud.githubusercontent.com/assets/121045/15266940/b8cbc5e8-19ee-11e6-9b70-905bfbb30b4a.png)


PR後は「パラメタ」と表示されてしまっています。
こちらも合わせて「パラメータ」に直したかったのですが
どこで設定されているかよくわからなかったので、そのままにしています。